### PR TITLE
feat(config): adds an option to split 'down' a.o.t. the default 'right'

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,29 +13,37 @@ export default {
         order: 2,
         description: 'Open the preview in a split pane. If disabled, the preview is opened in a new tab in the same pane.'
     },
+    directionToSplitPreviewPaneIn: {
+        type: 'string',
+        "default": 'right',
+        order: 3,
+        description: "The direction to split the preview pane to. Usually you want that to be 'right' " +
+                     "(the default), unless you edit with a vertical display when 'bottom' is probably better.",
+        "enum": ['right', 'down']
+    },
     useGraphvizCommandLine: {
         type: 'boolean',
         "default": false,
-        order: 3,
+        order: 4,
         description: 'Keep unchecked when in doubt.<ul><li>Checked:<br>state-machine-cat-preview will use the command line version of GraphViz dot. For this to work GraphViz has to be installed on your machine, and it has to be on your path.<li>Unchecked:<br>state-machine-cat-preview will use viz.js for rendering.</ul>'
     },
     GraphvizPath: {
         type: 'string',
         "default": '',
-        order: 4,
+        order: 5,
         description: 'If you use the command line version of GraphViz, and GraphViz is not on your _path_, you can use this to specify where to find the executable (including the name of the executable e.g. `/Users/superman/bin/dot`).<br><br>Leave empty when it\'s on your path.'
     },
     direction: {
         type: 'string',
         "default": "top-down",
-        order: 5,
+        order: 6,
         description: "The direction to render the state machine in",
         "enum": ['top-down', 'left-right']
     },
     layoutEngine: {
         type: 'string',
         "default": 'dot',
-        order: 6,
+        order: 7,
         description: "The engine smcat uses to layout the diagram. **dot** delivers the\nbest results.\n\nIn some edge cases other engines perform better. Note that\nonly _dot_, _fdp_ and _osage_ understand composite state machines.",
         "enum": ['dot', 'circo', 'fdp', 'neato', 'osage', 'twopi']
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -111,11 +111,11 @@ module.exports = {
         };
 
         if (atom.config.get('state-machine-cat-preview.openPreviewInSplitPane')) {
-            options.split = 'right';
+            options.split = atom.config.get('state-machine-cat-preview.directionToSplitPreviewPaneIn') || 'right';
         }
         return atom.workspace.open(uri, options).then(function(pStateMachineCatPreviewView) {
             if (isStateMachineCatPreviewView(pStateMachineCatPreviewView)) {
-                return previousActivePane.activate();
+                previousActivePane.activate();
             }
         });
     }


### PR DESCRIPTION
## Description
See title

## Motivation and Context
- This is practical if you're working on a vertical display.
- It's also practical when your state machine is rendered left-to-right

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.